### PR TITLE
skel.pp does not respect source_dir_purge variable

### DIFF
--- a/manifests/skel.pp
+++ b/manifests/skel.pp
@@ -27,7 +27,7 @@ class nagios::skel {
     group   => $nagios::config_file_group,
     require => File['nagios_configdir'],
     recurse => true,
-    purge   => true,
+    purge   => $nagios::bool_source_dir_purge,
     force   => true,
   }
 
@@ -39,7 +39,7 @@ class nagios::skel {
     group   => $nagios::config_file_group,
     require => File['nagios_configdir'],
     recurse => true,
-    purge   => true,
+    purge   => $nagios::bool_source_dir_purge,
     force   => true,
   }
 


### PR DESCRIPTION
I noticed that even though I told "class nagios" not to purge the source directory, files were being purged in services and hosts.

This changes creates support for skel.pp to not purge these directories.
