### PR TITLE
Added documentation of 'nagios_customconfigdir' for Debian users

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           audit_only => true
         }
 
+* Debian (and derivatives) users must set the top scope variable `nagios_customconfigdir` to point to the Nagios configuration directory. At the moment, this directory is not parameterized based on operating system
+
+        $nagios_customconfigdir = '/etc/nagios3/auto.d'
+        class { 'nagios': }
+
 
 ## USAGE - Overrides and Customizations
 * Use custom sources for main config file 


### PR DESCRIPTION
As discussed on https://github.com/example42/puppet-nagios/issues/5, here is at least some documentation. I'll see if I have time to implement parameterization based on OS today. If not today, it will have to wait quite some time ... sorry
