### PR TITLE
Checking for host definition before defining again

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -21,8 +21,10 @@ class nagios::target {
   # TODO: Find a smarter solution that doesn't requre TopScope Variables
   $magic_tag = get_magicvar($::nagios_grouplogic)
 
-  nagios::host { $::fqdn: 
-    use => 'generic-host',
+  if !defined(Nagios::Host[$::fqdn]) {
+    nagios::host { $::fqdn:
+      use => 'generic-host',
+    }
   }
 
   nagios::baseservices { $::fqdn:


### PR DESCRIPTION
In the example in host.pp, it says to use $fqdn for the name. Inside of nagios::host, nagios::target is included and the host is defined again in target using $::fqdn. This should fix that issue.
