### PR TITLE
Adding a nagios_baseservices_template global variable

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -32,8 +32,13 @@ class nagios::target {
     }
   }
 
+  $baseservices_template = $::nagios_baseservices_template ? {
+    ''      => 'nagios/baseservices.erb',
+    default => $::nagios_baseservices_template,
+  }
   nagios::baseservices { $::fqdn:
-    use => 'generic-service',
+    use      => 'generic-service',
+    template => $baseservices_template,
   }
 
   include nagios::plugins


### PR DESCRIPTION
I hate to add yet another global variable, but it's a much easier alternative to customizing nagios, nrpe, and monitor classes to meet my needs.
