### PR TITLE
adding selinux file resource for check_yum and other custom plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -28,13 +28,17 @@ define nagios::plugin (
 
   if ( $source != 'no' ) {
     file { "nagios_plugin_${name}":
-      ensure  => $ensure,
-      path    => "${nrpe::pluginsdir}/${name}",
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755',
-      source  => "puppet:///modules/${real_source}",
-      require => Class['nrpe'],
+      ensure   => $ensure,
+      path     => "${nrpe::pluginsdir}/${name}",
+      owner    => 'root',
+      group    => 'root',
+      mode     => '0755',
+      source   => "puppet:///modules/${real_source}",
+      require  => Class['nrpe'],
+      seluser  => 'system_u',
+      selrole  => 'object_r',
+      seltype  => 'nagios_system_plugin_exec_t',
+      selrange => 's0',
     }
   }
 


### PR DESCRIPTION
I have tested on OracleLinux.  Based selinux properties from existing checks provided by plugin package -

  # ls -axlZ check_load
  -rwxr-xr-x. root root system_u:object_r:nagios_system_plugin_exec_t:s0 check_load
  # ls -axlZ check_yum
  -rwxr-xr-x. root root system_u:object_r:bin_t:s0       check_yum

After puppet agent run -
  # ls -axlZ check_yum
  -rwxr-xr-x. root root   system_u:object_r:nagios_system_plugin_exec_t:s0 check_yum
